### PR TITLE
input sensor trust

### DIFF
--- a/CMFA_ESR.adoc
+++ b/CMFA_ESR.adoc
@@ -140,6 +140,8 @@ NOTE: Explicit user permission is required if CMFA monitors detailed user behavi
 
 *CMFA shall configure an adequate set of sensors for continuous authentication.*
 
+*CMFA shall define the trust (reliability) of all input sensors.*
+
 *CMFA shall continuously determine the current level of confidence in the authentication of a user based on inputs from sensors and configuration data.*
 
 [NOTE]


### PR DESCRIPTION
Adding an ESR to explicitly assign trust to input sensors. This is actually to close #22 by instead of worrying specifically about how to check any input, that the vendor must define how it is trusted.